### PR TITLE
pythohn3 -> python in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ some script to setup garaemon's environment
 ```sh
 git clone git@github.com:garaemon/garaemon-settings.git
 cd garaemon-settings
-ansible-playbook -i localhost, -c local main.yml --ask-become-pass --extra-vars="ansible_python_interpreter=/usr/bin/python"
+ansible-playbook -i localhost, -c local main.yml --ask-become-pass --extra-vars="ansible_python_interpreter=/usr/bin/python3"
 ```
 
 ## Minimal Setup
@@ -15,5 +15,5 @@ ansible-playbook -i localhost, -c local main.yml --ask-become-pass --extra-vars=
 ```sh
 git clone git@github.com:garaemon/garaemon-settings.git
 cd garaemon-settings
-ansible-playbook -i localhost, -c local minimal.yml --ask-become-pass --extra-vars="ansible_python_interpreter=/usr/bin/python"
+ansible-playbook -i localhost, -c local minimal.yml --ask-become-pass --extra-vars="ansible_python_interpreter=/usr/bin/python3"
 ```


### PR DESCRIPTION
* On Ubuntu 24.04, `/usr/bin/python` is not
  available. Instead, `/usr/bin/python3` is available.
