### PR TITLE
Fix: ansible-lint command-instead-of-shell violations

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -6,7 +6,6 @@ skip_list:
     - var-naming
     - yaml
     - command-instead-of-module
-    - command-instead-of-shell
     - no-free-form
     - role-name
     - schema

--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -52,7 +52,7 @@
     - gh_auth_status.rc == 0
 
 - name: Remove github.com from known_hosts
-  shell: ssh-keygen -R github.com
+  command: ssh-keygen -R github.com
   ignore_errors: true
 
 - name: Add github.com to known_hosts

--- a/roles/circleci-cli/tasks/main.yml
+++ b/roles/circleci-cli/tasks/main.yml
@@ -1,4 +1,4 @@
 - name: Install circleci-cli
-  shell: go get -u github.com/CircleCI-Public/circleci-cli
+  command: go get -u github.com/CircleCI-Public/circleci-cli
   environment:
     GO111MODULE: 'on'

--- a/roles/starship/tasks/main.yml
+++ b/roles/starship/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: Check if starship is installed or not
-  shell: which starship
+  command: which starship
   ignore_errors: true
   register: which_starship
 

--- a/roles/vscode/tasks/main.yml
+++ b/roles/vscode/tasks/main.yml
@@ -4,7 +4,7 @@
   shell: |
     curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /tmp/microsoft.gpg
 - name: Install microsoft.gpg
-  shell:
+  command:
     install -o root -g root -m 644 /tmp/microsoft.gpg /etc/apt/trusted.gpg.d/
   become: true
 


### PR DESCRIPTION
Remove command-instead-of-shell from skip_list in .ansible-lint and fix violations in playbooks.