### PR TITLE
Fix: Use FQCN for apt module and remove profile from ansible-lint config

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,8 +1,6 @@
 ---
-profile: basic
 
 skip_list:
     - name
-    - no-free-form
     - role-name
     - schema

--- a/roles/apt/tasks/main.yml
+++ b/roles/apt/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: Install apt packages
-  apt:
+  ansible.builtin.apt:
     name: "{{ packages }}"
     state: present
     update_cache: true
@@ -39,7 +39,7 @@
       - xclip
       - zsh
 - name: Install apt packages (xenial)
-  apt:
+  ansible.builtin.apt:
     name: "{{ packages }}"
     state: present
     update_cache: true


### PR DESCRIPTION
ansible-lintの警告を修正しました。