### PR TITLE
Fix: Remove no-free-form from ansible-lint skip_list

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -3,6 +3,5 @@ profile: basic
 
 skip_list:
     - name
-    - no-free-form
     - role-name
     - schema


### PR DESCRIPTION
ansible-lintのskip_listからno-free-formを削除しました。