### PR TITLE
Handle existing config files gracefully in symlink roles

### DIFF
--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -81,18 +81,22 @@
   ignore_errors: true
   changed_when: false
 
+- name: Check if SSH authentication is working
+  set_fact:
+    ssh_auth_working: "{{ 'successfully authenticated' in ssh_test.stderr }}"
+
 - name: Update garaemon-settings only if on master branch (SSH)
   git:
     repo: git@github.com:garaemon/garaemon-settings.git
     dest: ~/gprog/garaemon-settings
   when:
-    - not repo_exists.stat.exists or (git_status is defined and git_status.version == "master")
-    - ssh_test.rc == 1
+    - not repo_exists.stat.exists or (git_status is defined and git_status.after == "master")
+    - ssh_auth_working | bool
 
 - name: Update garaemon-settings only if on master branch (HTTPS)
   git:
     repo: https://github.com/garaemon/garaemon-settings.git
     dest: ~/gprog/garaemon-settings
   when:
-    - not repo_exists.stat.exists or (git_status is defined and git_status.version == "master")
-    - ssh_test.rc != 1
+    - not repo_exists.stat.exists or (git_status is defined and git_status.after == "master")
+    - not (ssh_auth_working | bool)

--- a/roles/clang_format/tasks/main.yml
+++ b/roles/clang_format/tasks/main.yml
@@ -5,11 +5,26 @@
   become: true
   when: ansible_os_family == "Debian"
 
-- name: Check if clang-format exists and is not a symlink
+- name: Check if clang-format exists
   stat:
     path: ~/.clang-format
   register: clang_format_stat
-  failed_when: clang_format_stat.stat.exists and not clang_format_stat.stat.islnk
+
+- name: Check file differences for clang-format
+  command: diff ~/.clang-format ~/gprog/garaemon-settings/roles/clang_format/files/clang-format
+  register: clang_format_diff
+  failed_when: false
+  changed_when: false
+  when: clang_format_stat.stat.exists and not clang_format_stat.stat.islnk
+
+- name: Remove existing clang-format if identical to target
+  file:
+    path: ~/.clang-format
+    state: absent
+  when:
+    - clang_format_stat.stat.exists
+    - not clang_format_stat.stat.islnk
+    - clang_format_diff.rc == 0
 
 - name: Create symlink for clang-format
   file:

--- a/roles/emacs/tasks/main.yml
+++ b/roles/emacs/tasks/main.yml
@@ -9,6 +9,27 @@
     dest: "{{ ansible_env.HOME }}/gprog/emacs.d"
   when: not emacs_d_exists.stat.exists
 
+- name: Check if .emacs.d exists
+  stat:
+    path: ~/.emacs.d
+  register: emacs_d_link_stat
+
+- name: Check if .emacs.d directories are identical
+  command: diff -r ~/.emacs.d ~/gprog/emacs.d
+  register: emacs_d_diff
+  failed_when: false
+  changed_when: false
+  when: emacs_d_link_stat.stat.exists and not emacs_d_link_stat.stat.islnk
+
+- name: Remove existing .emacs.d if identical to target
+  file:
+    path: ~/.emacs.d
+    state: absent
+  when:
+    - emacs_d_link_stat.stat.exists
+    - not emacs_d_link_stat.stat.islnk
+    - emacs_d_diff.rc == 0
+
 - name: Symlink for emacs.d
   file:
     src: ~/gprog/emacs.d

--- a/roles/ghostty/tasks/main.yml
+++ b/roles/ghostty/tasks/main.yml
@@ -8,11 +8,26 @@
         state: directory
         mode: "0755"
 
-    - name: Check if ghostty config exists and is not a symlink
+    - name: Check if ghostty config exists
       stat:
         path: "{{ ansible_env.HOME }}/Library/Application Support/com.mitchellh.ghostty/config"
       register: ghostty_config_stat
-      failed_when: ghostty_config_stat.stat.exists and not ghostty_config_stat.stat.islnk
+
+    - name: Check file differences for ghostty config
+      command: diff "{{ ansible_env.HOME }}/Library/Application Support/com.mitchellh.ghostty/config" ~/gprog/garaemon-settings/roles/ghostty/files/config
+      register: ghostty_config_diff
+      failed_when: false
+      changed_when: false
+      when: ghostty_config_stat.stat.exists and not ghostty_config_stat.stat.islnk
+
+    - name: Remove existing ghostty config if identical to target
+      file:
+        path: "{{ ansible_env.HOME }}/Library/Application Support/com.mitchellh.ghostty/config"
+        state: absent
+      when:
+        - ghostty_config_stat.stat.exists
+        - not ghostty_config_stat.stat.islnk
+        - ghostty_config_diff.rc == 0
 
     - name: Create symlink for ghostty config
       file:

--- a/roles/git/tasks/main.yml
+++ b/roles/git/tasks/main.yml
@@ -75,11 +75,26 @@
     scope: global
     value: "~/.gitignore"
 
-- name: Check if gitignore exists and is not a symlink
+- name: Check if gitignore exists
   stat:
     path: ~/.gitignore
   register: gitignore_stat
-  failed_when: gitignore_stat.stat.exists and not gitignore_stat.stat.islnk
+
+- name: Check file differences for gitignore
+  command: diff ~/.gitignore ~/gprog/garaemon-settings/roles/git/tasks/files/gitignore
+  register: gitignore_diff
+  failed_when: false
+  changed_when: false
+  when: gitignore_stat.stat.exists and not gitignore_stat.stat.islnk
+
+- name: Remove existing gitignore if identical to target
+  file:
+    path: ~/.gitignore
+    state: absent
+  when:
+    - gitignore_stat.stat.exists
+    - not gitignore_stat.stat.islnk
+    - gitignore_diff.rc == 0
 
 - name: Create symlink for global gitignore
   file:

--- a/roles/karabiner/tasks/main.yml
+++ b/roles/karabiner/tasks/main.yml
@@ -4,12 +4,30 @@
     state: directory
   when: ansible_os_family == "Darwin"
 
-- name: Check if karabiner config exists and is not a symlink
+- name: Check if karabiner config exists
   stat:
     path: ~/.config/karabiner/karabiner.json
   register: karabiner_stat
-  failed_when: karabiner_stat.stat.exists and not karabiner_stat.stat.islnk
   when: ansible_os_family == "Darwin"
+
+- name: Check file differences for karabiner config
+  command: diff ~/.config/karabiner/karabiner.json ~/gprog/garaemon-settings/roles/karabiner/files/karabiner.json
+  register: karabiner_diff
+  failed_when: false
+  changed_when: false
+  when:
+    - ansible_os_family == "Darwin"
+    - karabiner_stat.stat.exists and not karabiner_stat.stat.islnk
+
+- name: Remove existing karabiner config if identical to target
+  file:
+    path: ~/.config/karabiner/karabiner.json
+    state: absent
+  when:
+    - ansible_os_family == "Darwin"
+    - karabiner_stat.stat.exists
+    - not karabiner_stat.stat.islnk
+    - karabiner_diff.rc == 0
 
 - name: Create symlink for karabiner configuration
   file:

--- a/roles/python_language_server/tasks/main.yml
+++ b/roles/python_language_server/tasks/main.yml
@@ -4,11 +4,26 @@
 #     . ~/.pyenv/.pyenvrc &&
 #     pyenv shell 3.7.2
 #     pip install 'python-language-server[all]'
-- name: Check if pycodestyle config exists and is not a symlink
+- name: Check if pycodestyle config exists
   stat:
     path: ~/.config/pycodestyle
   register: pycodestyle_stat
-  failed_when: pycodestyle_stat.stat.exists and not pycodestyle_stat.stat.islnk
+
+- name: Check file differences for pycodestyle
+  command: diff ~/.config/pycodestyle ~/gprog/garaemon-settings/roles/python_language_server/files/pycodestyle
+  register: pycodestyle_diff
+  failed_when: false
+  changed_when: false
+  when: pycodestyle_stat.stat.exists and not pycodestyle_stat.stat.islnk
+
+- name: Remove existing pycodestyle if identical to target
+  file:
+    path: ~/.config/pycodestyle
+    state: absent
+  when:
+    - pycodestyle_stat.stat.exists
+    - not pycodestyle_stat.stat.islnk
+    - pycodestyle_diff.rc == 0
 
 - name: Create symlink for pycodestyle config
   file:

--- a/roles/starship/tasks/main.yml
+++ b/roles/starship/tasks/main.yml
@@ -33,11 +33,26 @@
     path: '{{ ansible_env.HOME }}/.config'
     state: directory
 
-- name: Check if starship.toml exists and is not a symlink
+- name: Check if starship.toml exists
   stat:
     path: '{{ ansible_env.HOME }}/.config/starship.toml'
   register: starship_toml_stat
-  failed_when: starship_toml_stat.stat.exists and not starship_toml_stat.stat.islnk
+
+- name: Check file differences for starship.toml
+  command: diff '{{ ansible_env.HOME }}/.config/starship.toml' ~/gprog/garaemon-settings/roles/starship/files/starship.toml
+  register: starship_toml_diff
+  failed_when: false
+  changed_when: false
+  when: starship_toml_stat.stat.exists and not starship_toml_stat.stat.islnk
+
+- name: Remove existing starship.toml if identical to target
+  file:
+    path: '{{ ansible_env.HOME }}/.config/starship.toml'
+    state: absent
+  when:
+    - starship_toml_stat.stat.exists
+    - not starship_toml_stat.stat.islnk
+    - starship_toml_diff.rc == 0
 
 - name: Create symlink for starship.toml
   file:

--- a/roles/tig/tasks/main.yml
+++ b/roles/tig/tasks/main.yml
@@ -1,8 +1,23 @@
-- name: Check if tigrc exists and is not a symlink
+- name: Check if tigrc exists
   stat:
     path: ~/.tigrc
   register: tigrc_stat
-  failed_when: tigrc_stat.stat.exists and not tigrc_stat.stat.islnk
+
+- name: Check file differences for tigrc
+  command: diff ~/.tigrc ~/gprog/garaemon-settings/roles/tig/files/tigrc
+  register: tigrc_diff
+  failed_when: false
+  changed_when: false
+  when: tigrc_stat.stat.exists and not tigrc_stat.stat.islnk
+
+- name: Remove existing tigrc if identical to target
+  file:
+    path: ~/.tigrc
+    state: absent
+  when:
+    - tigrc_stat.stat.exists
+    - not tigrc_stat.stat.islnk
+    - tigrc_diff.rc == 0
 
 - name: Create symlink for tigrc
   file:

--- a/roles/tmux/tasks/main.yml
+++ b/roles/tmux/tasks/main.yml
@@ -1,8 +1,23 @@
-- name: Check if tmux.conf exists and is not a symlink
+- name: Check if tmux.conf exists
   stat:
     path: ~/.tmux.conf
   register: tmux_conf_stat
-  failed_when: tmux_conf_stat.stat.exists and not tmux_conf_stat.stat.islnk
+
+- name: Check file differences for tmux.conf
+  command: diff ~/.tmux.conf ~/gprog/garaemon-settings/roles/tmux/files/tmux.conf
+  register: tmux_conf_diff
+  failed_when: false
+  changed_when: false
+  when: tmux_conf_stat.stat.exists and not tmux_conf_stat.stat.islnk
+
+- name: Remove existing tmux.conf if identical to target
+  file:
+    path: ~/.tmux.conf
+    state: absent
+  when:
+    - tmux_conf_stat.stat.exists
+    - not tmux_conf_stat.stat.islnk
+    - tmux_conf_diff.rc == 0
 
 - name: Create symlink for tmux.conf
   file:

--- a/roles/vim/tasks/main.yml
+++ b/roles/vim/tasks/main.yml
@@ -1,8 +1,23 @@
-- name: Check if vimrc exists and is not a symlink
+- name: Check if vimrc exists
   stat:
     path: ~/.vimrc
   register: vimrc_stat
-  failed_when: vimrc_stat.stat.exists and not vimrc_stat.stat.islnk
+
+- name: Check file differences for vimrc
+  command: diff ~/.vimrc ~/gprog/garaemon-settings/roles/vim/files/vimrc
+  register: vimrc_diff
+  failed_when: false
+  changed_when: false
+  when: vimrc_stat.stat.exists and not vimrc_stat.stat.islnk
+
+- name: Remove existing vimrc if identical to target
+  file:
+    path: ~/.vimrc
+    state: absent
+  when:
+    - vimrc_stat.stat.exists
+    - not vimrc_stat.stat.islnk
+    - vimrc_diff.rc == 0
 
 - name: Create symlink for vimrc
   file:

--- a/roles/zsh/tasks/main.yml
+++ b/roles/zsh/tasks/main.yml
@@ -1,38 +1,128 @@
-- name: Check if zshrc exists and is not a symlink
+- name: Check if zshrc exists
   stat:
     path: ~/.zshrc
   register: zshrc_stat
-  failed_when: zshrc_stat.stat.exists and not zshrc_stat.stat.islnk
 
-- name: Check if zlogin exists and is not a symlink
+- name: Check file differences for zshrc
+  command: diff ~/.zshrc ~/gprog/garaemon-settings/roles/zsh/files/zshrc
+  register: zshrc_diff
+  failed_when: false
+  changed_when: false
+  when: zshrc_stat.stat.exists and not zshrc_stat.stat.islnk
+
+- name: Remove existing zshrc if identical to target
+  file:
+    path: ~/.zshrc
+    state: absent
+  when:
+    - zshrc_stat.stat.exists
+    - not zshrc_stat.stat.islnk
+    - zshrc_diff.rc == 0
+
+- name: Check if zlogin exists
   stat:
     path: ~/.zlogin
   register: zlogin_stat
-  failed_when: zlogin_stat.stat.exists and not zlogin_stat.stat.islnk
 
-- name: Check if zlogout exists and is not a symlink
+- name: Check file differences for zlogin
+  command: diff ~/.zlogin ~/gprog/garaemon-settings/roles/zsh/files/zlogin
+  register: zlogin_diff
+  failed_when: false
+  changed_when: false
+  when: zlogin_stat.stat.exists and not zlogin_stat.stat.islnk
+
+- name: Remove existing zlogin if identical to target
+  file:
+    path: ~/.zlogin
+    state: absent
+  when:
+    - zlogin_stat.stat.exists
+    - not zlogin_stat.stat.islnk
+    - zlogin_diff.rc == 0
+
+- name: Check if zlogout exists
   stat:
     path: ~/.zlogout
   register: zlogout_stat
-  failed_when: zlogout_stat.stat.exists and not zlogout_stat.stat.islnk
 
-- name: Check if zprofile exists and is not a symlink
+- name: Check file differences for zlogout
+  command: diff ~/.zlogout ~/gprog/garaemon-settings/roles/zsh/files/zlogout
+  register: zlogout_diff
+  failed_when: false
+  changed_when: false
+  when: zlogout_stat.stat.exists and not zlogout_stat.stat.islnk
+
+- name: Remove existing zlogout if identical to target
+  file:
+    path: ~/.zlogout
+    state: absent
+  when:
+    - zlogout_stat.stat.exists
+    - not zlogout_stat.stat.islnk
+    - zlogout_diff.rc == 0
+
+- name: Check if zprofile exists
   stat:
     path: ~/.zprofile
   register: zprofile_stat
-  failed_when: zprofile_stat.stat.exists and not zprofile_stat.stat.islnk
 
-- name: Check if zshenv exists and is not a symlink
+- name: Check file differences for zprofile
+  command: diff ~/.zprofile ~/gprog/garaemon-settings/roles/zsh/files/zprofile
+  register: zprofile_diff
+  failed_when: false
+  changed_when: false
+  when: zprofile_stat.stat.exists and not zprofile_stat.stat.islnk
+
+- name: Remove existing zprofile if identical to target
+  file:
+    path: ~/.zprofile
+    state: absent
+  when:
+    - zprofile_stat.stat.exists
+    - not zprofile_stat.stat.islnk
+    - zprofile_diff.rc == 0
+
+- name: Check if zshenv exists
   stat:
     path: ~/.zshenv
   register: zshenv_stat
-  failed_when: zshenv_stat.stat.exists and not zshenv_stat.stat.islnk
 
-- name: Check if zshrc.zplug exists and is not a symlink
+- name: Check file differences for zshenv
+  command: diff ~/.zshenv ~/gprog/garaemon-settings/roles/zsh/files/zshenv
+  register: zshenv_diff
+  failed_when: false
+  changed_when: false
+  when: zshenv_stat.stat.exists and not zshenv_stat.stat.islnk
+
+- name: Remove existing zshenv if identical to target
+  file:
+    path: ~/.zshenv
+    state: absent
+  when:
+    - zshenv_stat.stat.exists
+    - not zshenv_stat.stat.islnk
+    - zshenv_diff.rc == 0
+
+- name: Check if zshrc.zplug exists
   stat:
     path: ~/.zshrc.zplug
   register: zshrc_zplug_stat
-  failed_when: zshrc_zplug_stat.stat.exists and not zshrc_zplug_stat.stat.islnk
+
+- name: Check file differences for zshrc.zplug
+  command: diff ~/.zshrc.zplug ~/gprog/garaemon-settings/roles/zsh/files/zshrc.zplug
+  register: zshrc_zplug_diff
+  failed_when: false
+  changed_when: false
+  when: zshrc_zplug_stat.stat.exists and not zshrc_zplug_stat.stat.islnk
+
+- name: Remove existing zshrc.zplug if identical to target
+  file:
+    path: ~/.zshrc.zplug
+    state: absent
+  when:
+    - zshrc_zplug_stat.stat.exists
+    - not zshrc_zplug_stat.stat.islnk
+    - zshrc_zplug_diff.rc == 0
 
 - name: Create symlink for zshrc
   file:


### PR DESCRIPTION
## Summary

- Updated all roles to check file differences before creating symlinks instead of immediately failing
- Added logic to compare existing files with target files using `diff` command
- Remove existing files only if they're identical to target files to allow symlink creation
- Fixed SSH authentication check in base role (`git_status.after` vs `git_status.version`)
- Removed all trailing spaces to ensure ansible-lint passes

## Changes Made

**Updated 12 roles with improved symlink handling:**
- `base`, `zsh`, `git`, `vim`, `tmux`, `emacs`, `tig`, `starship`, `python_language_server`, `karabiner`, `clang_format`, `ghostty`

**New behavior:**
1. Check if destination files exist and are not symlinks
2. Compare file contents using `diff` when files exist
3. Remove existing files only if identical to target (allowing symlink creation)
4. Protect against overwriting different configurations

## Test Plan

- [x] All roles pass `ansible-lint` with 0 errors and 0 warnings
- [x] GitHub Actions lint workflow passes locally via `act -j lint` 
- [x] Changes tested across all modified roles
- [x] Trailing spaces removed from all YAML files

## Benefits

- Prevents Ansible failures when identical config files already exist
- Maintains protection against overwriting customized configurations  
- Allows seamless conversion from regular files to symlinks when content matches
- Improves robustness of the setup process

🤖 Generated with [Claude Code](https://claude.ai/code)