### PR TITLE
Update git role to avoid sudo when git is already installed

### DIFF
--- a/roles/git/tasks/main.yml
+++ b/roles/git/tasks/main.yml
@@ -1,8 +1,18 @@
+- name: Check if git is installed
+  apt:
+    name: git
+    state: present
+  check_mode: true
+  register: git_check
+  when: ansible_os_family == "Debian"
+
 - name: Install git
   apt:
     name: git
   become: true
-  when: ansible_os_family == "Debian"
+  when:
+    - ansible_os_family == "Debian"
+    - git_check.changed
 
 - name: Git config core.pager
   community.general.git_config:


### PR DESCRIPTION
## Summary
- Modified git role to check if git is already installed before attempting installation
- Only runs `apt install git` with sudo when git package is not present
- Allows minimal.yml to run without `--ask-become-pass` when git is already installed

## Changes
- Added check task using `apt` module with `check_mode: true` to detect if git needs installation
- Modified install task to only run when `git_check.changed` is true
- Fixed YAML formatting issues (changed `yes` to `true`, removed trailing spaces)

## Test plan
- [x] Linter passes with `act -j lint`
- [x] Git role only attempts sudo installation when git is missing
- [ ] Test minimal.yml execution without `--ask-become-pass` on system with git pre-installed

🤖 Generated with [Claude Code](https://claude.ai/code)