### PR TITLE
Add claude role to manage ~/.claude/CLAUDE.md configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,8 +21,11 @@ This is an Ansible-based dotfiles and system configuration repository for settin
 # Full setup
 ansible-playbook -i localhost, -c local main.yml --ask-become-pass
 
-# Minimal setup
+# Minimal setup (can run without sudo if git is already installed)
 ansible-playbook -i localhost, -c local minimal.yml --ask-become-pass
+
+# Minimal setup without sudo (when git is pre-installed)
+ansible-playbook -i localhost, -c local minimal.yml
 
 # Install specific role
 ansible-playbook -i localhost, -c local --tags "role_name" main.yml --ask-become-pass
@@ -57,6 +60,19 @@ Roles use Ansible conditionals for cross-platform compatibility:
 - `ansible_os_family == "Darwin"` for macOS-specific tasks
 - `ansible_os_family == "Debian"` for Linux-specific tasks
 - `ansible_architecture != 'aarch64'` for architecture-specific exclusions
+
+## Sudo Policy
+
+### minimal.yml
+- **Can run without sudo** when git is already installed on the system
+- Only requires sudo for git package installation on Debian/Ubuntu systems
+- The git role checks if git is installed before attempting installation with sudo
+- All other roles (dotfiles, symlinks, configurations) run without sudo privileges
+
+### main.yml
+- **Requires sudo** for package installation and system-level configuration
+- Uses `--ask-become-pass` flag for elevated privileges
+- Installs system packages via apt (Linux) or homebrew (macOS)
 
 ## Memories
 

--- a/main.yml
+++ b/main.yml
@@ -9,6 +9,7 @@
     - tmux
     - zsh
     - starship
+    - claude
     - role: apt
       when: ansible_os_family == "Debian"
     - role: homebrew

--- a/minimal.yml
+++ b/minimal.yml
@@ -8,6 +8,7 @@
     - tmux
     - zsh
     - starship
+    - claude
     - uv
     - peco
     - nvm

--- a/roles/claude/files/CLAUDE.md
+++ b/roles/claude/files/CLAUDE.md
@@ -1,0 +1,9 @@
+- Before you make a PR, always run tests including linters.
+- You don't need to include test programs in linter.
+- Keep the function shorter. One function is recommended to be shorter than 90 lines.
+- Don't implement many things at once. Always compile programs or run test codes after you modify the code.
+- Always start functions and methods with verbs.
+- Always use descriptive names for variables.
+- Avoid class inheritance basically. You should not use class inheritance to reduce duplicated codes. The exceptional cases are 1. libraries require inheritance. 2. You need inheritance of types.
+- When you make a branch, Add YYYY.MM.DD- prefix to the name.
+- Do not add trailing spaces

--- a/roles/claude/tasks/main.yml
+++ b/roles/claude/tasks/main.yml
@@ -10,7 +10,7 @@
   register: claude_md_stat
 
 - name: Check file differences for CLAUDE.md
-  command: diff ~/.claude/CLAUDE.md ~/gprog/garaemon-settings/roles/claude/files/CLAUDE.md
+  command: diff ~/.claude/CLAUDE.md {{ playbook_dir }}/roles/claude/files/CLAUDE.md
   register: claude_md_diff
   failed_when: false
   changed_when: false
@@ -27,6 +27,6 @@
 
 - name: Create symlink for CLAUDE.md
   file:
-    src: ~/gprog/garaemon-settings/roles/claude/files/CLAUDE.md
+    src: "{{ playbook_dir }}/roles/claude/files/CLAUDE.md"
     dest: ~/.claude/CLAUDE.md
     state: link

--- a/roles/claude/tasks/main.yml
+++ b/roles/claude/tasks/main.yml
@@ -1,0 +1,32 @@
+- name: Ensure .claude directory exists
+  file:
+    path: ~/.claude
+    state: directory
+    mode: '0755'
+
+- name: Check if CLAUDE.md exists
+  stat:
+    path: ~/.claude/CLAUDE.md
+  register: claude_md_stat
+
+- name: Check file differences for CLAUDE.md
+  command: diff ~/.claude/CLAUDE.md ~/gprog/garaemon-settings/roles/claude/files/CLAUDE.md
+  register: claude_md_diff
+  failed_when: false
+  changed_when: false
+  when: claude_md_stat.stat.exists and not claude_md_stat.stat.islnk
+
+- name: Remove existing CLAUDE.md if identical to target
+  file:
+    path: ~/.claude/CLAUDE.md
+    state: absent
+  when:
+    - claude_md_stat.stat.exists
+    - not claude_md_stat.stat.islnk
+    - claude_md_diff.rc == 0
+
+- name: Create symlink for CLAUDE.md
+  file:
+    src: ~/gprog/garaemon-settings/roles/claude/files/CLAUDE.md
+    dest: ~/.claude/CLAUDE.md
+    state: link


### PR DESCRIPTION
## Summary
- Add new Ansible role to manage ~/.claude/CLAUDE.md configuration file
- Creates symlink from ~/.claude/CLAUDE.md to repository template file
- Follows established patterns from other dotfile roles (zsh, tmux, vim, etc.)
- Added to both main.yml and minimal.yml playbooks

## Test plan
- [ ] Run `ansible-playbook -i localhost, -c local --tags "claude" main.yml` to test role
- [ ] Verify ~/.claude directory is created with proper permissions
- [ ] Verify symlink is created correctly pointing to repository file
- [ ] Test that existing files are handled properly (diff check and removal if identical)
- [ ] Confirm ansible-lint passes (already verified)

🤖 Generated with [Claude Code](https://claude.ai/code)