### PR TITLE
Enable allow-passthrough for tmux 3.3+

### DIFF
--- a/roles/tmux/files/tmux.conf
+++ b/roles/tmux/files/tmux.conf
@@ -71,4 +71,8 @@ bind "#" split-window -c "#{pane_current_path}" -h
 run '~/.tmux/plugins/tpm/tpm'
 setw -g aggressive-resize off
 
-set -g allow-passthrough on
+# Newer than 3.3
+if-shell "tmux -V | awk '{ print $2 }' | awk -F. '{ if ($1 > 3 || ($1 >= 3 && $2 >= 3)) exit 0; exit 1 }'" {
+    # allow-passthrough is added from tmux 3.3.
+    set -g allow-passthrough on
+}


### PR DESCRIPTION
- Ensure allow-passthrough is set on for newer tmux versions.
- This utilizes an if-shell command to check the tmux version.
- Only sets allow-passthrough if the version is 3.3 or greater.