### PR TITLE
Fix mise access rate limit errors with retry mechanism

### DIFF
--- a/roles/claude/tasks/main.yml
+++ b/roles/claude/tasks/main.yml
@@ -35,3 +35,7 @@
   command: mise use -g claude
   environment:
     PATH: "{{ ansible_env.HOME }}/.local/bin:{{ ansible_env.PATH }}"
+  retries: 3
+  delay: 5
+  register: claude_claude_install_result
+  until: claude_claude_install_result.rc == 0

--- a/roles/git/tasks/main.yml
+++ b/roles/git/tasks/main.yml
@@ -19,6 +19,10 @@
   command: mise use -g delta
   environment:
     PATH: "{{ ansible_env.HOME }}/.local/bin:{{ ansible_env.PATH }}"
+  retries: 3
+  delay: 5
+  register: git_delta_install_result
+  until: git_delta_install_result.rc == 0
 
 # configurations for delta
 - name: Use delta as git pager

--- a/roles/typescript_language_server/tasks/main.yml
+++ b/roles/typescript_language_server/tasks/main.yml
@@ -2,3 +2,7 @@
   command: mise exec -- npm install -g typescript-language-server
   environment:
     PATH: "{{ ansible_env.HOME }}/.local/bin:{{ ansible_env.PATH }}"
+  retries: 3
+  delay: 5
+  register: typescript_language_server_typescript_ls_install_result
+  until: typescript_language_server_typescript_ls_install_result.rc == 0


### PR DESCRIPTION
## Summary
- Add retry logic to mise commands that frequently fail in CI with "too many requests" errors
- Apply retries: 3 and delay: 5 to all mise use commands in roles
- Ensure compliance with Ansible lint variable naming requirements

## Test plan
- [x] Run ansible-lint to verify code quality
- [x] Test playbook execution in CI environment
- [ ] Verify retry mechanism works under rate limit conditions

🤖 Generated with [Claude Code](https://claude.ai/code)