### PR TITLE
Fix GitHub API rate limit errors in CI by adding MISE_GITHUB_TOKEN

### DIFF
--- a/.github/workflows/ansible-macos.yml
+++ b/.github/workflows/ansible-macos.yml
@@ -39,6 +39,7 @@ jobs:
           ansible-playbook main.yml -i localhost, --connection=local
         env:
           ANSIBLE_HOST_KEY_CHECKING: "False" # Often useful in CI/CD for local connections
+          MISE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   test-minimal-macos:
     runs-on: macos-latest
@@ -68,3 +69,4 @@ jobs:
           ansible-playbook minimal.yml -i localhost, --connection=local
         env:
           ANSIBLE_HOST_KEY_CHECKING: "False" # Often useful in CI/CD for local connections
+          MISE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Execute minimal.yml
         run: ansible-playbook -i localhost, -c local minimal.yml -v
+        env:
+          MISE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   main:
     runs-on: ${{ matrix.os }}
@@ -61,3 +63,5 @@ jobs:
 
       - name: Execute main.yml
         run: ansible-playbook -i localhost, -c local main.yml -v
+        env:
+          MISE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Added MISE_GITHUB_TOKEN environment variable to all GitHub Actions workflows
- Fixes 403 rate limit exceeded errors when mise downloads tools from GitHub API
- Uses the automatically provided GITHUB_TOKEN secret for authentication

## Test plan
- [x] Verify that CI workflows no longer fail with rate limit errors
- [x] Confirm that tool installation (like delta) succeeds in GitHub Actions
- [x] Check that both main.yml and minimal.yml playbooks work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)