### PR TITLE
Add keyboard role to configure caps lock as additional control key

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -30,6 +30,8 @@
       when: ansible_os_family == "Debian"
     - role: dictd
       when: ansible_os_family == "Debian"
+    - role: keyboard
+      when: ansible_os_family == "Debian"
     - python_language_server
     - typescript_language_server
     - ghostty

--- a/roles/keyboard/handlers/main.yml
+++ b/roles/keyboard/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Reconfigure keyboard
+  command: dpkg-reconfigure -f noninteractive keyboard-configuration
+  become: true

--- a/roles/keyboard/tasks/main.yml
+++ b/roles/keyboard/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+- name: Configure keyboard to use caps lock as additional control key
+  lineinfile:
+    path: /etc/default/keyboard
+    regexp: '^XKBOPTIONS='
+    line: 'XKBOPTIONS="ctrl:nocaps"'
+    backup: true
+  become: true
+  when: ansible_os_family == "Debian"
+  notify: Reconfigure keyboard
+
+- name: Apply keyboard configuration
+  command: dpkg-reconfigure -f noninteractive keyboard-configuration
+  become: true
+  when: ansible_os_family == "Debian"


### PR DESCRIPTION
## Summary
- Add new keyboard role for Debian systems only
- Configure /etc/default/keyboard with XKBOPTIONS="ctrl:nocaps"
- Add keyboard role to main.yml playbook

## Test plan
- [ ] Test on Debian system to verify caps lock functions as control key
- [ ] Verify role only runs on Debian systems
- [ ] Check that keyboard configuration is properly applied

🤖 Generated with [Claude Code](https://claude.ai/code)