### PR TITLE
Add enchant package installation to enchant role

### DIFF
--- a/roles/enchant/tasks/main.yml
+++ b/roles/enchant/tasks/main.yml
@@ -1,4 +1,17 @@
 ---
+- name: "Install enchant on Debian/Ubuntu"
+  apt:
+    name: enchant-2
+    state: present
+  become: true
+  when: ansible_os_family == "Debian"
+
+- name: "Install enchant on macOS"
+  homebrew:
+    name: enchant
+    state: present
+  when: ansible_os_family == "Darwin"
+
 - name: "Create .config/enchant directory"
   file:
     path: "{{ ansible_env.HOME }}/.config/enchant"


### PR DESCRIPTION
## Summary
- Add enchant package installation via apt on Debian/Ubuntu systems
- Add enchant package installation via homebrew on macOS
- Ensure enchant is installed before creating configuration directory and symlink

## Test plan
- [ ] Verify enchant installs correctly on Debian/Ubuntu via apt
- [ ] Verify enchant installs correctly on macOS via homebrew
- [ ] Verify configuration directory and symlink are created after installation
- [ ] Run `act -j lint` to ensure code quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)