### PR TITLE
Add create-pr.md command configuration to claude role

### DIFF
--- a/roles/claude/files/create-pr.md
+++ b/roles/claude/files/create-pr.md
@@ -1,0 +1,15 @@
+---
+allowed-tools: Bash(gh:*), Bash(git:*), Read(.github/*)
+description: "Push a Pull Request Draft (PR Number Optional)"
+---
+
+Make a pull request with the following steps:
+
+1. Make a branch. The branch should start with YYYY.MM.DD- prefix.
+If you are on a branch, you don't need to make a branch.
+2. If there is local change, make a commit.
+3. Update origin repository
+4. Check the diff between the current branch and the default branch in origin repository.
+5. Check the commits with the actual diff and commit message
+6. Make a PR by
+7. Open a browser by `gh pr view --web`

--- a/roles/claude/files/create-pr.md
+++ b/roles/claude/files/create-pr.md
@@ -11,5 +11,5 @@ If you are on a branch, you don't need to make a branch.
 3. Update origin repository
 4. Check the diff between the current branch and the default branch in origin repository.
 5. Check the commits with the actual diff and commit message
-6. Make a PR by
+6. Make a PR by `gh pr create`.
 7. Open a browser by `gh pr view --web`

--- a/roles/claude/tasks/main.yml
+++ b/roles/claude/tasks/main.yml
@@ -9,8 +9,10 @@
     path: ~/.claude/CLAUDE.md
   register: claude_md_stat
 
+
+# TODO: it does not work if we run this role for a different host
 - name: Check file differences for CLAUDE.md
-  command: diff ~/.claude/CLAUDE.md ~/gprog/garaemon-settings/roles/claude/files/CLAUDE.md
+  command: diff ~/.claude/CLAUDE.md "{{ role_path }}/files/CLAUDE.md"
   register: claude_md_diff
   failed_when: false
   changed_when: false
@@ -27,7 +29,7 @@
 
 - name: Create symlink for CLAUDE.md
   file:
-    src: ~/gprog/garaemon-settings/roles/claude/files/CLAUDE.md
+    src: "{{ role_path }}/files/CLAUDE.md"
     dest: ~/.claude/CLAUDE.md
     state: link
 
@@ -43,7 +45,7 @@
   register: claude_create_pr_stat
 
 - name: Check file differences for create-pr.md
-  command: diff ~/.claude/commands/create-pr.md ~/gprog/garaemon-settings/roles/claude/files/create-pr.md
+  command: diff ~/.claude/commands/create-pr.md "{{ role_path }}/files/create-pr.md"
   register: claude_create_pr_diff
   failed_when: false
   changed_when: false
@@ -60,7 +62,7 @@
 
 - name: Create symlink for create-pr.md
   file:
-    src: ~/gprog/garaemon-settings/roles/claude/files/create-pr.md
+    src: "{{ role_path }}/files/create-pr.md"
     dest: ~/.claude/commands/create-pr.md
     state: link
 

--- a/roles/claude/tasks/main.yml
+++ b/roles/claude/tasks/main.yml
@@ -31,6 +31,39 @@
     dest: ~/.claude/CLAUDE.md
     state: link
 
+- name: Ensure .claude/commands directory exists
+  file:
+    path: ~/.claude/commands
+    state: directory
+    mode: '0755'
+
+- name: Check if create-pr.md exists
+  stat:
+    path: ~/.claude/commands/create-pr.md
+  register: claude_create_pr_stat
+
+- name: Check file differences for create-pr.md
+  command: diff ~/.claude/commands/create-pr.md ~/gprog/garaemon-settings/roles/claude/files/create-pr.md
+  register: claude_create_pr_diff
+  failed_when: false
+  changed_when: false
+  when: claude_create_pr_stat.stat.exists and not claude_create_pr_stat.stat.islnk
+
+- name: Remove existing create-pr.md if identical to target
+  file:
+    path: ~/.claude/commands/create-pr.md
+    state: absent
+  when:
+    - claude_create_pr_stat.stat.exists
+    - not claude_create_pr_stat.stat.islnk
+    - claude_create_pr_diff.rc == 0
+
+- name: Create symlink for create-pr.md
+  file:
+    src: ~/gprog/garaemon-settings/roles/claude/files/create-pr.md
+    dest: ~/.claude/commands/create-pr.md
+    state: link
+
 - name: Install Claude Code via mise
   command: mise use -g claude
   environment:


### PR DESCRIPTION
## Summary
- Add create-pr.md command file to roles/claude/files/
- Install create-pr.md to ~/.claude/commands/ with symlink management
- Follow the same pattern as CLAUDE.md configuration

## Test plan
- [x] Run ansible-playbook to verify symlink creation
- [ ] Verify ~/.claude/commands/create-pr.md is created as symlink
- [ ] Confirm linter passes (already verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)