### PR TITLE
Add fingerprint_mafp role for MicroArray MAFP reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,16 @@ ghq get git@github.com:garaemon/garaemon-settings.git
 cd $(ghq root)/github.com/garaemon/garaemon-settings
 ansible-playbook -i localhost, -c local minimal.yml --ask-become-pass
 ```
+
+## Host-specific Setup
+
+### ax8-max
+
+Runs `main.yml` plus host-specific roles for the ax8-max machine (e.g. the
+MicroArray MAFP fingerprint reader, see `roles/fingerprint_mafp`).
+
+```sh
+ghq get git@github.com:garaemon/garaemon-settings.git
+cd $(ghq root)/github.com/garaemon/garaemon-settings
+ansible-playbook -i localhost, -c local ax8-max.yml --ask-become-pass
+```

--- a/ax8-max.yml
+++ b/ax8-max.yml
@@ -1,0 +1,8 @@
+- name: Import base playbook
+  import_playbook: main.yml
+
+- name: Apply ax8-max specific settings
+  hosts: all
+  roles:
+    - role: fingerprint_mafp
+      when: ansible_facts.os_family == "Debian" and ansible_facts.architecture == "x86_64"

--- a/roles/fingerprint_mafp/README.md
+++ b/roles/fingerprint_mafp/README.md
@@ -1,0 +1,100 @@
+# fingerprint_mafp
+
+Builds and installs a libfprint TOD (Touch OEM Driver) module for the MicroArray
+"MAFP General Device" fingerprint reader (USB `3274:8012`), which is not supported
+by upstream libfprint/fprintd.
+
+The driver is the reverse-engineered `jdillon/libfprint-microarray` driver,
+compiled as a standalone TOD module so it drops a single `.so` into
+`/usr/lib/<arch>/libfprint-2/tod-1/` without replacing the system
+`libfprint-2.so`.
+
+## What it does
+
+- Installs the fprintd stack and TOD build dependencies via apt.
+- Clones the driver source at a pinned revision and builds it with the
+  role-provided `tod_glue.c` and `Makefile`.
+- Installs the TOD module, a udev rule for non-root USB access, and (optionally)
+  enables fingerprint authentication via PAM with the password kept as fallback.
+
+Only runs on Debian/Ubuntu (`x86_64`).
+
+## Variables
+
+See `defaults/main.yml`:
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `fingerprint_mafp_enabled` | `true` | Build and install the driver. |
+| `fingerprint_mafp_driver_repo` | jdillon repo | Upstream driver source. |
+| `fingerprint_mafp_driver_version` | pinned commit | Revision built (reproducible). |
+| `fingerprint_mafp_build_dir` | under `ghq` root | Clone/build directory. |
+| `fingerprint_mafp_enable_pam` | `true` | Enable fingerprint login/sudo/unlock. |
+
+## Enrolling a fingerprint
+
+After the role runs, confirm the device is detected:
+
+```bash
+fprintd-list "$USER"        # lists enrolled fingers (or "no devices" if not detected)
+```
+
+Enroll a finger (default is `right-index-finger`):
+
+```bash
+fprintd-enroll                          # enrolls right-index-finger
+fprintd-enroll -f left-index-finger     # enroll a specific finger
+```
+
+Press and lift the finger repeatedly until it reports `enroll-completed`
+(6 samples). Valid finger names: `{left,right}-{thumb,index,middle,ring,little}-finger`.
+
+The sensor stores up to 30 templates, so multiple fingers can be enrolled.
+
+Verify the enrolled finger:
+
+```bash
+fprintd-verify              # should report verify-match for an enrolled finger
+```
+
+Delete enrolled fingerprints:
+
+```bash
+fprintd-delete "$USER"
+```
+
+## Using the fingerprint for login / sudo / unlock
+
+PAM is enabled by the role (`fingerprint_mafp_enable_pam: true`). Once a finger
+is enrolled, `sudo`, the login screen, and the screen-unlock prompt accept the
+fingerprint, falling back to the password if it fails or times out. Test with:
+
+```bash
+sudo -k && sudo true        # should prompt for a fingerprint
+```
+
+## Troubleshooting
+
+- **`No devices available` / not detected:** replug the reader, then
+  `sudo systemctl restart fprintd`. Confirm the device is on the bus with
+  `lsusb | grep 3274:8012`.
+- **`AlreadyInUse: Device was already claimed`** (often after Ctrl-C during
+  enroll): `sudo systemctl restart fprintd`, then retry.
+- **Permission errors claiming the USB interface:** ensure the udev rule is
+  loaded with `sudo udevadm control --reload-rules && sudo udevadm trigger`.
+
+## Rollback
+
+```bash
+sudo pam-auth-update --disable fprintd
+sudo rm /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/libfprint-2/tod-1/libfprint-tod-mafp.so
+sudo rm /etc/udev/rules.d/99-mafp.rules
+sudo udevadm control --reload-rules
+sudo systemctl restart fprintd
+```
+
+## Notes
+
+This is a third-party, reverse-engineered driver. The source was audited for
+unsafe memory handling and side effects before use; it is a pure USB protocol
+implementation with no file/network/privilege access.

--- a/roles/fingerprint_mafp/defaults/main.yml
+++ b/roles/fingerprint_mafp/defaults/main.yml
@@ -1,0 +1,16 @@
+---
+# Build and install the MicroArray MAFP (USB 3274:8012) fingerprint TOD driver.
+fingerprint_mafp_enabled: true
+
+# Upstream source of the reverse-engineered driver (jdillon microarray.c).
+# Pinned to a specific commit so the build stays reproducible.
+fingerprint_mafp_driver_repo: https://github.com/jdillon/libfprint-microarray
+fingerprint_mafp_driver_version: 82cd97eef8cddc551c067557f6e4b3af6426b9ba
+
+# Directory the driver source is cloned into and built in.
+fingerprint_mafp_build_dir: >-
+  {{ (ghq_root_path | default(ansible_facts.env.HOME + '/ghq'))
+     + '/github.com/jdillon/libfprint-microarray' }}
+
+# Enable fingerprint authentication via PAM (password is kept as fallback).
+fingerprint_mafp_enable_pam: true

--- a/roles/fingerprint_mafp/files/99-mafp.rules
+++ b/roles/fingerprint_mafp/files/99-mafp.rules
@@ -1,0 +1,4 @@
+# Allow non-root access to the MicroArray MAFP fingerprint reader so fprintd
+# (running as the seat user) can claim the USB interface.
+SUBSYSTEM=="usb", ATTRS{idVendor}=="3274", ATTRS{idProduct}=="8012", MODE="0660", GROUP="plugdev", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="3274", ATTRS{idProduct}=="8008", MODE="0660", GROUP="plugdev", TAG+="uaccess"

--- a/roles/fingerprint_mafp/files/Makefile
+++ b/roles/fingerprint_mafp/files/Makefile
@@ -1,0 +1,18 @@
+# Build the MicroArray MAFP fingerprint driver as a libfprint (+tod1) TOD module.
+# Requires the libfprint-2-tod-dev package, which ships the internal
+# drivers_api.h header that microarray.c includes.
+PKG    := libfprint-2-tod-1
+CC     ?= cc
+CFLAGS += -O2 -fPIC -Wall $(shell pkg-config --cflags $(PKG) gmodule-2.0)
+LIBS   := $(shell pkg-config --libs $(PKG) gmodule-2.0)
+SO     := libfprint-tod-mafp.so
+
+all: $(SO)
+
+$(SO): microarray.c tod_glue.c
+	$(CC) -shared $(CFLAGS) -o $@ microarray.c tod_glue.c $(LIBS)
+
+clean:
+	rm -f $(SO)
+
+.PHONY: all clean

--- a/roles/fingerprint_mafp/files/tod_glue.c
+++ b/roles/fingerprint_mafp/files/tod_glue.c
@@ -1,0 +1,22 @@
+/*
+ * TOD module glue for the MicroArray MAFP fingerprint driver.
+ *
+ * The jdillon microarray driver is an in-tree libfprint driver that exports
+ * fpi_device_microarray_get_type(). Ubuntu's libfprint is built with the TOD
+ * (Touch OEM Driver) loader, which instead looks up a single well-known entry
+ * point, fpi_tod_shared_driver_get_type(), in each *.so under tod-1/. This shim
+ * re-exports the driver's GType under that name so it can be loaded as a TOD
+ * module without replacing the system libfprint-2.so.
+ */
+#include <glib-object.h>
+#include <gmodule.h>
+
+extern GType fpi_device_microarray_get_type (void);
+
+G_MODULE_EXPORT GType fpi_tod_shared_driver_get_type (void);
+
+GType
+fpi_tod_shared_driver_get_type (void)
+{
+  return fpi_device_microarray_get_type ();
+}

--- a/roles/fingerprint_mafp/handlers/main.yml
+++ b/roles/fingerprint_mafp/handlers/main.yml
@@ -1,0 +1,10 @@
+---
+- name: Reload udev rules
+  ansible.builtin.shell: udevadm control --reload-rules && udevadm trigger
+  become: true
+
+- name: Restart fprintd
+  systemd:
+    name: fprintd
+    state: restarted
+  become: true

--- a/roles/fingerprint_mafp/tasks/main.yml
+++ b/roles/fingerprint_mafp/tasks/main.yml
@@ -1,0 +1,99 @@
+---
+- name: Build and install the MAFP fingerprint driver
+  when:
+    - fingerprint_mafp_enabled
+    - ansible_facts.os_family == "Debian"
+    - ansible_facts.architecture == "x86_64"
+  block:
+    - name: Install fprintd stack and TOD build dependencies
+      apt:
+        name:
+          - libfprint-2-tod1
+          - libfprint-2-tod-dev
+          - fprintd
+          - libpam-fprintd
+          - build-essential
+          - pkg-config
+        state: present
+      become: true
+
+    - name: Determine multiarch library tuple
+      ansible.builtin.command: dpkg-architecture -qDEB_HOST_MULTIARCH
+      register: fingerprint_mafp_multiarch
+      changed_when: false
+
+    - name: Clone MAFP driver source at pinned revision
+      ansible.builtin.git:
+        repo: "{{ fingerprint_mafp_driver_repo }}"
+        dest: "{{ fingerprint_mafp_build_dir }}"
+        version: "{{ fingerprint_mafp_driver_version }}"
+        update: false
+
+    - name: Install TOD glue into the driver source tree
+      copy:
+        src: tod_glue.c
+        dest: "{{ fingerprint_mafp_build_dir }}/src/tod_glue.c"
+        mode: "0644"
+      register: fingerprint_mafp_glue
+
+    - name: Install TOD Makefile into the driver source tree
+      copy:
+        src: Makefile
+        dest: "{{ fingerprint_mafp_build_dir }}/src/Makefile"
+        mode: "0644"
+      register: fingerprint_mafp_makefile
+
+    - name: Check for an existing build artifact
+      stat:
+        path: "{{ fingerprint_mafp_build_dir }}/src/libfprint-tod-mafp.so"
+      register: fingerprint_mafp_built_so
+
+    - name: Build the MAFP TOD module
+      ansible.builtin.command:
+        cmd: make
+        chdir: "{{ fingerprint_mafp_build_dir }}/src"
+      when: >-
+        not fingerprint_mafp_built_so.stat.exists
+        or fingerprint_mafp_glue.changed
+        or fingerprint_mafp_makefile.changed
+      register: fingerprint_mafp_make
+      changed_when: fingerprint_mafp_make.rc == 0
+
+    - name: Create the TOD driver directory
+      file:
+        path: "/usr/lib/{{ fingerprint_mafp_multiarch.stdout }}/libfprint-2/tod-1"
+        state: directory
+        mode: "0755"
+      become: true
+
+    - name: Install the MAFP TOD module
+      copy:
+        src: "{{ fingerprint_mafp_build_dir }}/src/libfprint-tod-mafp.so"
+        dest: "/usr/lib/{{ fingerprint_mafp_multiarch.stdout }}/libfprint-2/tod-1/libfprint-tod-mafp.so"
+        remote_src: true
+        mode: "0644"
+      become: true
+      notify: Restart fprintd
+
+    - name: Install the MAFP udev rule
+      copy:
+        src: 99-mafp.rules
+        dest: /etc/udev/rules.d/99-mafp.rules
+        mode: "0644"
+      become: true
+      notify: Reload udev rules
+
+    - name: Check whether fprintd PAM is already enabled
+      ansible.builtin.command: grep -q pam_fprintd.so /etc/pam.d/common-auth
+      register: fingerprint_mafp_pam_check
+      changed_when: false
+      failed_when: false
+      when: fingerprint_mafp_enable_pam
+
+    - name: Enable fprintd PAM module with password fallback
+      ansible.builtin.command: pam-auth-update --package --enable fprintd
+      become: true
+      when:
+        - fingerprint_mafp_enable_pam
+        - fingerprint_mafp_pam_check.rc != 0
+      notify: Restart fprintd


### PR DESCRIPTION
## Enable the MicroArray MAFP fingerprint reader on Linux

The MicroArray "MAFP General Device" reader (USB `3274:8012`) is unsupported by
upstream libfprint/fprintd — `fprintd-list` reports no devices. This adds a
`fingerprint_mafp` role that makes the reader usable for enroll/verify and for
PAM (sudo / login / screen unlock).

## Build the driver as a TOD module instead of replacing system libfprint

The role builds the reverse-engineered `jdillon/libfprint-microarray` driver as
a standalone libfprint TOD (Touch OEM Driver) module, cloned at a pinned
revision and compiled with a role-provided `tod_glue.c` and `Makefile` against
`libfprint-2-tod-dev`. This drops a single `.so` into
`/usr/lib/<arch>/libfprint-2/tod-1/` without replacing the system
`libfprint-2.so`. The role also installs a udev rule for non-root USB access and
enables fprintd PAM with the password kept as fallback.

## Scope to the ax8-max host via a dedicated playbook

The reader is hardware specific to the ax8-max machine, so the role is applied
from a new `ax8-max.yml` playbook (which imports `main.yml`) rather than from
`main.yml` itself. Other machines are unaffected.

## Documentation

`roles/fingerprint_mafp/README.md` covers variables, fingerprint enrollment
(`fprintd-enroll`/`fprintd-verify`), PAM usage, troubleshooting, and rollback.

## Verification

- Built the driver in a clean `ubuntu:24.04` container; the resulting `.so` is
  byte-for-byte identical (matching sha256) to the working driver already
  installed on the host.
- `ansible-playbook --syntax-check ax8-max.yml` passes.
- `ansible-lint` passes with 0 failures (production profile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)