### PR TITLE
Document repository scope and boundary with private-server-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,23 @@
 
 some script to setup garaemon's environment
 
+## Scope
+
+This repository configures the **interactive desktop environment** of a host,
+set up locally (editor, shell, keyboard, fonts, fingerprint reader, etc.). Some
+machines, such as `ax8-max`, are also configured in
+[`private-server-config`](https://github.com/garaemon/private-server-config).
+The boundary is the concern, not the machine:
+
+- **garaemon-settings** (this repo): the interactive desktop environment of a
+  host that is set up locally.
+- **private-server-config**: headless server services for a host, managed
+  remotely over SSH (Docker, Prometheus, Jenkins, Jupyter, Plex, Tailscale,
+  etc.).
+
+Device- and login-oriented settings (for example the MAFP fingerprint reader on
+`ax8-max`) belong here, not in `private-server-config`.
+
 ## INSTALL
 
 ```sh


### PR DESCRIPTION
## Summary

Add a "Scope" section to the README clarifying what this repository covers and
how it differs from `private-server-config`.

- This repo: the interactive desktop environment of a host, set up locally
  (editor, shell, keyboard, fonts, fingerprint reader, etc.).
- `private-server-config`: headless server services managed remotely over SSH.
- The boundary is the concern, not the machine. Device- and login-oriented
  settings (e.g. the MAFP fingerprint reader on `ax8-max`) belong here.

A symmetric note is added on the `private-server-config` side in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)