### PR TITLE
Add onepassword role to install the 1Password desktop app

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -32,6 +32,8 @@
       when: ansible_facts.os_family == "Debian"
     - role: chrome
       when: ansible_facts.os_family == "Debian" and ansible_facts.architecture == "x86_64"
+    - role: onepassword
+      when: ansible_facts.os_family == "Debian" and ansible_facts.architecture == "x86_64"
     - typescript_language_server
     - ghostty_install
   vars:

--- a/roles/onepassword/README.md
+++ b/roles/onepassword/README.md
@@ -1,0 +1,42 @@
+# onepassword
+
+Installs the 1Password desktop app from the official apt repository.
+
+The `.deb` package is preferred over Flatpak/Snap because system
+authentication (polkit) integration works reliably only with the native
+package.
+
+## What it does
+
+- Skips everything when the `1password` command already exists.
+- Installs the 1Password signing key into `/usr/share/keyrings/`.
+- Registers the official apt repository with `signed-by`.
+- Installs the `1password` package.
+
+Only runs on Debian/Ubuntu (`x86_64`).
+
+## Unlocking with a fingerprint
+
+1Password unlocks through polkit and PAM. If `pam_fprintd.so` is enabled in
+`/etc/pam.d/common-auth` (see the `fingerprint_mafp` role) and a finger is
+enrolled, follow these steps:
+
+1. Open 1Password and sign in with the master password.
+2. Go to Settings > Security and enable "Unlock using system authentication".
+3. Lock 1Password and unlock it again. The polkit dialog accepts the
+   fingerprint.
+
+Notes:
+
+- The master password is always required after a reboot or the first app
+  launch. The fingerprint only re-unlocks a session that was unlocked once.
+- To let the `op` CLI reuse the app unlock, enable
+  Settings > Developer > "Integrate with 1Password CLI".
+
+## Troubleshooting
+
+- **The unlock dialog only asks for a password:** confirm that polkit reaches
+  the fingerprint PAM module. Without `/etc/pam.d/polkit-1`, PAM falls back to
+  `/etc/pam.d/other`, which includes `common-auth`.
+- **The fingerprint prompt does not appear:** verify enrollment with
+  `fprintd-verify` and check `systemctl status fprintd`.

--- a/roles/onepassword/tasks/main.yml
+++ b/roles/onepassword/tasks/main.yml
@@ -1,0 +1,67 @@
+- name: Install 1Password desktop app
+  when:
+    - ansible_facts.os_family == "Debian"
+    - ansible_facts.architecture == "x86_64"
+  block:
+    - name: Check if 1Password is already installed
+      command: which 1password
+      register: onepassword_installed
+      ignore_errors: true
+      changed_when: false
+
+    - name: Install 1Password from the official apt repository
+      when: onepassword_installed.rc != 0
+      block:
+        - name: Install dependencies for 1Password
+          apt:
+            name:
+              - gnupg
+            state: present
+          become: true
+
+        - name: Download 1Password signing key
+          get_url:
+            url: https://downloads.1password.com/linux/keys/1password.asc
+            dest: /tmp/1password-signing-key.asc
+            mode: "0644"
+
+        - name: Convert and install 1Password signing key to keyrings
+          ansible.builtin.shell: |
+            gpg --dearmor < /tmp/1password-signing-key.asc > /usr/share/keyrings/1password-archive-keyring.gpg
+          become: true
+          args:
+            creates: /usr/share/keyrings/1password-archive-keyring.gpg
+
+        - name: Set permissions on 1Password keyring
+          file:
+            path: /usr/share/keyrings/1password-archive-keyring.gpg
+            mode: "0644"
+          become: true
+
+        - name: Write 1Password repository file with signed-by
+          copy:
+            dest: /etc/apt/sources.list.d/1password.list
+            # The folded scalar keeps the repository definition on one line in the file.
+            content: >
+              deb [arch=amd64 signed-by=/usr/share/keyrings/1password-archive-keyring.gpg]
+              https://downloads.1password.com/linux/debian/amd64 stable main
+            mode: "0644"
+          become: true
+          register: onepassword_repository
+
+        - name: Update apt cache
+          apt:
+            update_cache: true
+          become: true
+          when: onepassword_repository.changed
+
+        - name: Install 1Password
+          apt:
+            name: 1password
+            state: present
+          become: true
+
+        - name: Clean up temporary signing key
+          file:
+            path: /tmp/1password-signing-key.asc
+            state: absent


### PR DESCRIPTION
## Install 1Password from the official apt repository

Adds a new `onepassword` role and enables it in `main.yml` for Debian/Ubuntu on `x86_64`.

The native `.deb` package is used instead of Flatpak/Snap because system authentication through polkit — including fingerprint unlock via `pam_fprintd` set up by the `fingerprint_mafp` role — works reliably only with the native package.

## Skip installation when 1Password already exists

The role checks `which 1password` first and skips the whole install block when the command is present, following the same pattern as `ghostty_install` and other roles in this repository. Otherwise it:

- installs the 1Password signing key into `/usr/share/keyrings/`
- registers the official apt repository with `signed-by`
- installs the `1password` package

## Verified locally

- `ansible-lint` passes (0 failures, 0 warnings; production profile)
- `ansible-playbook --syntax-check main.yml` passes
- A check-mode run on a host with 1Password installed skips all install tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013VWCgTkmB3E5XqM9UppdAG